### PR TITLE
Fix of error related to unicode char in author

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -241,7 +241,7 @@ class GitDataCollector(DataCollector):
             if 'lines_removed' not in a: a['lines_removed'] = 0
 
     def getAuthorInfo(self, author):
-        return self.authors[author]
+        return self.authors[author.encode("utf-8")]
 
     def getAuthors(self, limit=None):
         res = getkeyssortedbyvaluekey(self.authors, 'commits')


### PR DESCRIPTION
It fixes the following error that occurs when author contains a unicode char:
```
...
Refining data...
Generating report...
Traceback (most recent call last):
  File "./gitstats", line 745, in <module>
    g.run(sys.argv[1:])
  File "./gitstats", line 729, in run
    report.create(data, outputpath)
  File "./gitstats", line 331, in create
    authors_html = self.render_authors_page(data)
  File "./gitstats", line 539, in render_authors_page
    info = data.getAuthorInfo(author)
  File "./gitstats", line 244, in getAuthorInfo
    return self.authors[author]
KeyError: u'Marek Bry\u0161a'
```

Signed-off-by: Jan Beran <jberan@redhat.com>