### PR TITLE
bugfix: Decode fix. Explicit utf-8 encoding in export files.

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -309,13 +309,13 @@ class HTMLReportCreator(object):
         ###
         # General
         general_html = self.render_general_page(data)
-        with open(os.path.join(path, "general.html"), 'w') as f:
+        with open(os.path.join(path, "general.html"), 'w', encoding = 'utf-8') as f:
             f.write(general_html)
 
         ###
         # Activity
         activity_html = self.render_activity_page(data)
-        with open(os.path.join(path, "activity.html"), 'w') as f:
+        with open(os.path.join(path, "activity.html"), 'w', encoding = 'utf-8') as f:
             f.write(activity_html)
 
         # Commits by current year's months
@@ -334,7 +334,7 @@ class HTMLReportCreator(object):
         ###
         # Authors
         authors_html = self.render_authors_page(data)
-        with open(os.path.join(path, "authors.html"), 'w') as f:
+        with open(os.path.join(path, "authors.html"), 'w', encoding = 'utf-8') as f:
             if sys.version_info.major == 2:
                 f.write(authors_html)
             else:
@@ -393,7 +393,7 @@ class HTMLReportCreator(object):
         ###
         # Files
         files_html = self.render_files_page(data)
-        with open(os.path.join(path, "files.html"), 'w') as f:
+        with open(os.path.join(path, "files.html"), 'w', encoding = 'utf-8') as f:
             f.write(files_html)
 
         with open(os.path.join(path, 'files_by_date.dat'), 'w') as fg:
@@ -407,7 +407,7 @@ class HTMLReportCreator(object):
         ###
         # tags.html
         tags_html = self.render_tags_page(data)
-        with open(os.path.join(path, "tags.html"), 'w') as f:
+        with open(os.path.join(path, "tags.html"), 'w', encoding = 'utf-8') as f:
             if sys.version_info.major == 2:
                 f.write(tags_html)
             else:
@@ -416,7 +416,7 @@ class HTMLReportCreator(object):
         ###
         # about.html
         about_html = self.render_about_page()
-        with open(os.path.join(path, "about.html"), 'w') as f:
+        with open(os.path.join(path, "about.html"), 'w', encoding = 'utf-8') as f:
             if sys.version_info.major == 2:
                 f.write(about_html)
             else:

--- a/test/test_csvreportcreator.py
+++ b/test/test_csvreportcreator.py
@@ -28,7 +28,7 @@ class TestDictionaryListCsvExporte(BasicTestExporter):
         additional = {'projectname': 'Project Name Unit test', 'reponame': 'repostat'}
         exporter.export(file_name, self.gs.authors, additional)
         self.assertTrue(os.path.isfile(file_name))
-        self.assertTrue('Viktor Kopp;4028;3238' in open(file_name).read())
+        self.assertTrue('Viktor Kopp;4028;3238' in open(file_name, encoding = 'utf-8').read())
 
     def testCommitListExport(self):
         #test with list
@@ -37,7 +37,7 @@ class TestDictionaryListCsvExporte(BasicTestExporter):
         additional = {'projectname': 'Project Name Unit test', 'reponame': 'repostat'}
         exporter.export(file_name, self.gs.commits, additional)
         self.assertTrue(os.path.isfile(file_name))
-        self.assertTrue('Viktor Kopp;8;5;2018-10-15' in open(file_name).read())
+        self.assertTrue('Viktor Kopp;8;5;2018-10-15' in open(file_name, encoding = 'utf-8').read())
 
 
 class TestGeneralDictionaryCsvExporter(BasicTestExporter):
@@ -50,18 +50,18 @@ class TestGeneralDictionaryCsvExporter(BasicTestExporter):
             test_data[i] = {'projectname': 'Project Name Unit test', 'reponame': 'repostat'}
         exporter.export(file_name, test_data, False)
         self.assertTrue(os.path.isfile(file_name))
-        self.assertTrue('projectname;reponame' in open(file_name).read())
+        self.assertTrue('projectname;reponame' in open(file_name, encoding = 'utf-8').read())
 
-    def testGeneralDictionaryCsvExporterWithKeyDefault(self):
+    def testGeneralDictionaryCsvExporterWithKeyDefaultAndSpecChars(self):
         exporter = DictionaryCsvExporter()
         file_name = os.path.join(self.csv_outputdir, 'general_dict_export_withkeydef.csv')
         test_data = {}
         for i in range (0, 10):
-            test_data[i] = {'projectname': 'Project Name Unit test', 'reponame': 'repostat'}
+            test_data[i] = {'projectname': 'Project Name Unit test', 'reponame': 'repostat', 'special-chars-hu': 'árvíztűrőtükörfúrógépÁRVÍZTŰRŐTÜKÖRFÚRÓGÉP', 'special-chars-de':'ẞÄÖÜäöüß'}
         exporter.export(file_name, test_data)
         self.assertTrue(os.path.isfile(file_name))
-        self.assertTrue('projectname;reponame;key' in open(file_name).read())
-        self.assertTrue('Project Name Unit test;repostat;0' in open(file_name).read())
+        self.assertTrue('projectname;reponame;special-chars-hu;special-chars-de;key' in open(file_name, encoding = 'utf-8').read())
+        self.assertTrue('Project Name Unit test;repostat;árvíztűrőtükörfúrógépÁRVÍZTŰRŐTÜKÖRFÚRÓGÉP;ẞÄÖÜäöüß;0' in open(file_name, encoding='utf-8').read())
 
     def testGeneralDictionaryCsvExporterWithKeyUnit(self):
         exporter = DictionaryCsvExporter()
@@ -71,5 +71,5 @@ class TestGeneralDictionaryCsvExporter(BasicTestExporter):
             test_data[i] = {'projectname': 'Project Name Unit test', 'reponame': 'repostat'}
         exporter.export(file_name, test_data, True, 'Key UnitTestField')
         self.assertTrue(os.path.isfile(file_name))
-        self.assertTrue('projectname;reponame;Key UnitTestField' in open(file_name).read())
-        self.assertTrue('Project Name Unit test;repostat;0' in open(file_name).read())
+        self.assertTrue('projectname;reponame;Key UnitTestField' in open(file_name, encoding = 'utf-8').read())
+        self.assertTrue('Project Name Unit test;repostat;0' in open(file_name, encoding = 'utf-8').read())

--- a/test/test_gitstats.py
+++ b/test/test_gitstats.py
@@ -447,7 +447,7 @@ def get_total_changes_timeline():
             pos = line.find(' ')
             if pos != -1:
                 try:
-                    (stamp, author) = (long(line[:pos]), line[pos + 1:])
+                    (stamp, author) = (int(line[:pos]), line[pos + 1:])
                     changes_by_date[stamp] = {u'files': files, u'ins': inserted, u'del': deleted, u'lines': total_lines}
 
                     date = datetime.datetime.fromtimestamp(stamp)
@@ -601,7 +601,7 @@ class TestPygitMethods(unittest.TestCase):
         expected_data = []
         for line in revlines:
             ts, tree_id = line.split(' ')
-            expected_data.append((long(ts), tree_id))
+            expected_data.append((int(ts), tree_id))
 
         actual_data = []
         for t, r in self.gs.get_revisions():

--- a/tools/csvreportcreator.py
+++ b/tools/csvreportcreator.py
@@ -12,7 +12,7 @@ class DictionaryListCsvExporter():
 
 	@staticmethod
 	def export(file_name: str, data: dict, aditional_values: dict = None):
-		with open(file_name, 'w', newline='') as csvfile:
+		with open(file_name, 'w', newline='', encoding = 'utf-8') as csvfile:
 			fieldnames = []
 			data_list = []
 			if aditional_values == None:
@@ -40,7 +40,7 @@ class DictionaryCsvExporter():
 	
 	@staticmethod
 	def export(file_name: str, data: dict, export_key_as_field: bool = True, key_field_name: str = 'key'):
-		with open(file_name, 'w', newline='') as csvfile:
+		with open(file_name, 'w', newline='', encoding='utf-8') as csvfile:
 			fieldnames = list(data[list(data.keys())[0]].keys())
 			if export_key_as_field:
 				fieldnames.append(key_field_name)


### PR DESCRIPTION
Character encoding fix on export files (html, csv). Explicit UTF-8 encoding
Add encode spec chars test case to csv unit tests.


Bugfix:
export files encodnig is based on OS settings and the user can run in UnicodeEncodeError exception sometimes.

for example: 
'charmap' codec can't encode character '\u0171' in position 5: character maps to <**undefined**> python
