### PR TITLE
fetch all commits, consolidate commit info dict, use same struct

### DIFF
--- a/test/test_csvreportcreator.py
+++ b/test/test_csvreportcreator.py
@@ -38,9 +38,9 @@ class TestDictionaryListCsvExporte(BasicTestExporter):
         exporter = DictionaryListCsvExporter()
         file_name = os.path.join(self.csv_outputdir, 'commits.csv')
         additional = {'projectname': 'Project Name Unit test', 'reponame': 'repostat'}
-        exporter.export(file_name, self.gs.commits, additional)
+        exporter.export(file_name, self.gs.all_commits, additional)
         self.assertTrue(os.path.isfile(file_name))
-        self.assertTrue('Viktor Kopp;8;5;2018-10-15' in open(file_name, encoding='utf-8').read())
+        self.assertTrue('4;0;False;1539590122;2018-10-15 09:55:22' in open(file_name, encoding='utf-8').read())
 
 
 class TestGeneralDictionaryCsvExporter(BasicTestExporter):

--- a/test/test_gitstatistics.py
+++ b/test/test_gitstatistics.py
@@ -1,7 +1,9 @@
 import unittest
 import datetime
+import os
 from tools.gitstatistics import CommitDictFactory
 from tools.gitstatistics import AuthorDictFactory
+from tools.gitstatistics import GitStatistics
 
 
 class TestCommitDictFactory(unittest.TestCase):
@@ -119,6 +121,28 @@ class TestAuthorDictFactory(unittest.TestCase):
         AuthorDictFactory.check_last_commit_stamp(author, last_commit_after.timestamp())
         self.assertEqual(author[AuthorDictFactory.LAST_COMMIT], last_commit_after.timestamp())
         self.assertEqual(author[AuthorDictFactory.LAST_ACTIVE_DAY], '2019-03-20')
+
+
+class TestGitStatistics(unittest.TestCase):
+
+    @staticmethod
+    def get_gitstatistic():
+        this_file_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+        print('Init git repo. Path:' + this_file_dir)
+        return GitStatistics(this_file_dir)
+
+    def tesFetchAllCommits(self):
+        gs = TestGitStatistics.get_gitstatistic()
+        commits = dict()
+        gs.fetch_all_commits(commits)
+        print("Commit count {}".format(commits.__len__()))
+
+    def testFetchAuthorInfo(self):
+        gs = TestGitStatistics.get_gitstatistic()
+        authors = {}
+        commits = {}
+        gs.fetch_authors_info(authors, commits)
+        print("Commit count {}".format(len(commits)))
 
 
 if __name__ == '__main__':

--- a/tools/csvreportcreator.py
+++ b/tools/csvreportcreator.py
@@ -98,7 +98,7 @@ class CSVReportCreator(ReportCreator):
         DictionaryListCsvExporter.export(os.path.join(path, "authors.csv"), data.authors, aditional_info)
 
         # export commits
-        DictionaryListCsvExporter.export(os.path.join(path, "commits.csv"), data.commits, aditional_info)
+        DictionaryListCsvExporter.export(os.path.join(path, "commits.csv"), data.all_commits, aditional_info)
 
         # export total_history
         DictionaryListCsvExporter.export(os.path.join(path, "total_history.csv"), data.changes_history, aditional_info)
@@ -109,7 +109,7 @@ class CSVReportCreator(ReportCreator):
         # month of year
         lines_added_monthly = {}
         lines_removed_monthly = {}
-        for commit in data.commits:
+        for id, commit in data.all_commits.items():
             ts = commit[CommitDictFactory.TIMESTAMP]
             key = datetime.datetime.fromtimestamp(ts).strftime('%Y-%m')
             if key in lines_added_monthly.keys():

--- a/tools/htmlreportcreator.py
+++ b/tools/htmlreportcreator.py
@@ -12,6 +12,7 @@ import json
 from jinja2 import Environment, FileSystemLoader
 from tools.datacollector import GitDataCollector
 from tools.gitstatistics import GitStatistics
+from tools.gitstatistics import CommitDictFactory
 from tools import get_pipe_output
 from tools import Configuration
 
@@ -175,7 +176,8 @@ class HTMLReportCreator(object):
 
         with open(os.path.join(path, 'lines_of_code.dat'), 'w') as fg:
             for stamp in sorted(self.git_repo_statistics.changes_history.keys()):
-                fg.write('%d %d\n' % (stamp, self.git_repo_statistics.changes_history[stamp]['lines']))
+                fg.write(
+                    '%d %d\n' % (stamp, self.git_repo_statistics.changes_history[stamp][CommitDictFactory.LINE_COUNT]))
 
         ###
         # tags.html

--- a/tools/timeit.py
+++ b/tools/timeit.py
@@ -10,7 +10,10 @@ class Timeit(object):
         def wrapper(*args):
             if self.before_message is None:
                 self.before_message = method.__name__
-            print(self.before_message + "...")
+            try:
+                print(str(self.before_message + "...").format(*args))
+            except IndexError as ex:
+                print(self.before_message + "...")
             ts = time.time()
             result = method(*args)
             te = time.time()


### PR DESCRIPTION
- Consolidate commit dict structure. Same structure for commit informations in different list/dicts.
- GitStatistic improvement: fetch all commit from repo. (fetch from branches too, because unmerged branche's commits missed) total_history and author_info dicts are contain same info as before, but all_commit dict contain all commits info from repo, not only currently active branche
- TimeIt parameter format feature. Can use method params in message text.