### PR TITLE
Loosen version comparison

### DIFF
--- a/analysis/repostat.py
+++ b/analysis/repostat.py
@@ -20,13 +20,13 @@ time_start = time.time()
 
 
 class Requirements:
-    gnuplot_minimal_version = version.StrictVersion('5.2')
-    python_minimal_version = version.StrictVersion('3.5')
+    gnuplot_minimal_version = version.LooseVersion('5.2')
+    python_minimal_version = version.LooseVersion('3.5')
     gnuplot_executable = os.environ.get('GNUPLOT', 'gnuplot')
 
     def __init__(self, config: Configuration):
-        self.gnuplot_version = version.StrictVersion(config.get_gnuplot_version())
-        self.python_version = version.StrictVersion(sys.version.split()[0])
+        self.gnuplot_version = version.LooseVersion(config.get_gnuplot_version())
+        self.python_version = version.LooseVersion(sys.version.split()[0])
 
     def check(self):
         if self.python_version < self.python_minimal_version:


### PR DESCRIPTION
The checked tools may not follow the strict version pattern and we end
up with an exception in that case.

With my current setup on Debian 11/testing/bullseye I get the following behavior:
```
$ python3 --version
Python 3.7.5rc1
$ repostat --config_file <config_file> <git_dir> <out_dir>
/usr/lib/python3/dist-packages/tools/configuration.py:27: UserWarning: Directory <out_dir> already exists. Its content will be rewritten.
  warnings.warn("Directory {0} already exists. Its content will be rewritten.".format(prospective_dir))
 [0.00595] >> gnuplot --version
Traceback (most recent call last):
  File "/usr/bin/repostat", line 11, in <module>
    load_entry_point('repo-stat==1.0.0', 'console_scripts', 'repostat')()
  File "/usr/lib/python3/dist-packages/analysis/repostat.py", line 52, in main
    Requirements(config).check()
  File "/usr/lib/python3/dist-packages/analysis/repostat.py", line 28, in __init__
    self.python_version = version.StrictVersion(sys.version.split()[0])
  File "/usr/lib/python3.7/distutils/version.py", line 40, in __init__
    self.parse(vstring)
  File "/usr/lib/python3.7/distutils/version.py", line 137, in parse
    raise ValueError("invalid version number '%s'" % vstring)
ValueError: invalid version number '3.7.5rc1'
```