### PR TITLE
Allow for newer versions of pygit up to 0.28.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cffi==1.11.5
 Jinja2>=2.10.1
 MarkupSafe==1.0
-pygit2>=0.24.2,<=0.28
+pygit2>=0.24.2
 pytz>=2018.5
 six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='repo_stat',
           'cffi==1.11.5',
           'Jinja2>=2.10.1',
           'MarkupSafe==1.0',
-          'pygit2>=0.24.2,<=0.28',
+          'pygit2>=0.24.2',
           'pytz>=2018.5',
           'six>=1.11.0'
       ],


### PR DESCRIPTION
I'm running Ubuntu 18.04.1 

And in my repo python3-pycparser 2.18-2

With the pygit 0.28.0 module it gives this error below. Removing the upper limit pygit 0.28.2 is installed and it works with this pycparser. 

```
pkg_resources.DistributionNotFound: The 'pycparser<2.18' distribution was not found and is required by pygit2

```

Not sure if it's worth just removing the upper limit on this module or setting it higher.