### PR TITLE
Blame progress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Jinja2>=2.10.1
 pygit2>=1.0.3
 pytz>=2018.5
 pandas~=0.25.3
+tqdm~=4.45.0

--- a/tools/timeit.py
+++ b/tools/timeit.py
@@ -1,4 +1,5 @@
 import time
+from datetime import timedelta
 
 
 class Timeit(object):
@@ -14,6 +15,13 @@ class Timeit(object):
             ts = time.time()
             result = method(*args)
             te = time.time()
-            print('Finished in %2.2f ms' % ((te - ts) * 1000))
+
+            elapsed = (te - ts)
+            if elapsed < 1:
+                print('Elapsed time: %2.2f ms' % (elapsed * 1000))
+            else:
+                formatted = str(timedelta(seconds=elapsed))
+                print('Elapsed time: %s' % formatted)
+
             return result
         return wrapper


### PR DESCRIPTION
Added console progress bar to indicate progress of blame-data fetching when `--contribution` cmd option passed.

Attempt to add progress bar when fetching history data (commits-walking) did not succeed, as total number of commits has to be known in advance, which is equal to full history walk.