### PR TITLE
Re-introduce a commit by year/month graph

### DIFF
--- a/report/templates/activity.html
+++ b/report/templates/activity.html
@@ -90,6 +90,10 @@
     </tr>
  </table>
 
+<div style="border: 1px solid #808080; width: 768px" id="chart_commits_year_month">
+    <svg style="height: 500px; width: 100%"></svg>
+</div>
+
 <h2 id="commits_by_timezone"><a href="#commits_by_timezone">Commits by Timezone</a></h2>
 <table>
     <tr>

--- a/report/templates/activity.js
+++ b/report/templates/activity.js
@@ -35,6 +35,21 @@ nv.addGraph(function() {
 	return chart;
 });
 
+const commits_by_year_month = {{commits_by_year_month}}
+nv.addGraph(function() {
+    var chart = nv.models.lineChart();
+	chart.yAxis.options(commits_by_year_month.yAxis);
+	chart.xAxis.options(commits_by_year_month.xAxis);
+	chart.xAxis
+		.tickFormat(function(x) {
+			const month = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+			return month[x];
+	});
+
+    d3.select('#chart_commits_year_month svg').datum(commits_by_year_month.data).call(chart);
+    return chart;
+});
+
 nv.addGraph(function() {
   var chart = nv.models.discreteBarChart()
       .x(function(d) { return d.label })    //Specify the data accessors.


### PR DESCRIPTION
There was one in the old gitstats, but it was unreadable.

This new version overlays all the years on top of each other, and
highlight the current one, making it easy to compare the activity with
previous years and see general "quiet" months better.

Preview:

![commits_year_month](https://user-images.githubusercontent.com/2964297/100647052-3af4a580-333f-11eb-8cd9-627712e9c9c3.png)