### PR TITLE
Force commits by year/month, line and file charts to have Y=0

### DIFF
--- a/report/htmlreportcreator.py
+++ b/report/htmlreportcreator.py
@@ -441,15 +441,17 @@ class HTMLReportCreator:
         hst = self.git_repository_statistics.linear_history(self._time_sampling_interval).copy()
         hst["epoch"] = (hst.index - pd.Timestamp("1970-01-01 00:00:00+00:00")) // pd.Timedelta('1s') * 1000
 
-        files_count_ts = hst[["epoch", 'files_count']].rename(columns={"epoch": "x", 'files_count': "y"})\
-            .to_dict('records')
-        lines_count_ts = hst[["epoch", 'lines_count']].rename(columns={"epoch": "x", 'lines_count': "y"})\
-            .to_dict('records')
+        files_count_ts = hst[["epoch", 'files_count']].rename(columns={"epoch": "x", 'files_count': "y"})
+        lines_count_ts = hst[["epoch", 'lines_count']].rename(columns={"epoch": "x", 'lines_count': "y"})
+        maxFiles = int(files_count_ts.max()["y"])
+        maxLines = int(lines_count_ts.max()["y"])
         graph_data = {
             "data": [
-                {"key": "Files", "color": "#9400d3", "type": "line", "yAxis": 1, "values": files_count_ts},
-                {"key": "Lines", "color": "#d30094", "type": "line", "yAxis": 2, "values": lines_count_ts},
-            ]
+                {"key": "Files", "color": "#9400d3", "type": "line", "yAxis": 1, "values": files_count_ts.to_dict('records')},
+                {"key": "Lines", "color": "#d30094", "type": "line", "yAxis": 2, "values": lines_count_ts.to_dict('records')},
+            ],
+            "maxFiles": maxFiles,
+            "maxLines": maxLines
         }
 
         files_plot = JsPlot('files.js', json_data=json.dumps(graph_data))

--- a/report/templates/activity.js
+++ b/report/templates/activity.js
@@ -40,6 +40,7 @@ nv.addGraph(function() {
     var chart = nv.models.lineChart();
 	chart.yAxis.options(commits_by_year_month.yAxis);
 	chart.xAxis.options(commits_by_year_month.xAxis);
+	chart.forceY([0]);
 	chart.xAxis
 		.tickFormat(function(x) {
 			const month = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]

--- a/report/templates/files.js
+++ b/report/templates/files.js
@@ -5,6 +5,8 @@ nv.addGraph(function() {
 		.margin({left: 60, right: 60});
 	chart.yAxis1.options({axisLabel: "Files"});
 	chart.yAxis2.options({axisLabel: "Lines"});
+	chart.yDomain1([0, dataset.maxFiles]);
+	chart.yDomain2([0, dataset.maxLines]);
 	chart.xAxis
 		.tickFormat(function(d) { return d3.time.format('%Y-%m')(new Date(d)); })
 		.options({rotateLabels: -45})


### PR DESCRIPTION
By default the graph is clamped at the minimum value, which seems not
appropriate for projects that never had low activity or always had lots
of files/lines.

And in general it's a bit cleaner to have the axis start at 0.