### PR TITLE
Bumping Pandas version requirement to be >= 1.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=2.10.1
-pygit2>=1.0.3
+pygit2>=1.6.1
 pytz>=2018.5
-pandas>=0.25.3
+pandas>=1.3.3
 tqdm~=4.45.0


### PR DESCRIPTION
Pandas `0.25.3` is quite old and `1.*` has been released and stable for some time now.