### PR TITLE
Disable ubuntu 20.04 build with python 3.6

### DIFF
--- a/.github/workflows/repostat_ubuntu.yml
+++ b/.github/workflows/repostat_ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Build faild due to absense of pinned pandas dependency