### PR TITLE
Fix compatibility with pandas 2.0.1

### DIFF
--- a/.github/workflows/repostat_ubuntu.yml
+++ b/.github/workflows/repostat_ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 Python3-compatible Git repository analyser and HTML-report generator 
 with [nvd3](http://nvd3.org/) -driven interactive metrics visualisations.
 
-**May not work with Python 3.9+!** See https://github.com/vifactor/repostat/issues/198
-
 Initially, a fork of [gitstats](https://github.com/hoxu/gitstats) tool.
 
 ---

--- a/analysis/gitauthors.py
+++ b/analysis/gitauthors.py
@@ -12,7 +12,7 @@ class GitAuthors(object):
         authors_grouped = self.raw_authors_data[['author_name', 'author_datetime',
                                                  'insertions', 'deletions', 'is_merge_commit']].groupby(
             [self.raw_authors_data['author_name']])
-        self.authors_summary = authors_grouped.sum()
+        self.authors_summary = authors_grouped.sum(numeric_only=True)
         self.authors_summary['first_commit_date'] = authors_grouped['author_datetime'].min()
         self.authors_summary['latest_commit_date'] = authors_grouped['author_datetime'].max()
         self.authors_summary['active_days_count'] = authors_grouped['author_datetime'] \
@@ -55,7 +55,7 @@ class GitAuthors(object):
         wh_grouped = wh[['author_name', 'insertions', 'deletions']].groupby(
             [wh['author_name'], pd.Grouper(freq=sampling)])
 
-        modifications_over_time = wh_grouped.sum()\
+        modifications_over_time = wh_grouped.sum(numeric_only=True)\
             .reset_index()
 
         commits_over_time = wh_grouped.count().rename(columns={'author_name': 'commits_count'})\


### PR DESCRIPTION
Since in https://github.com/vifactor/repostat/blob/fc6e974e0010c2d6c9cb91e122e345e0440e18c6/requirements.txt#L4 pandas does not pin to 1.x, Python>=3.8 will have pandas 2.x installed.

In pandas 2.0.1, https://github.com/vifactor/repostat/blob/fc6e974e0010c2d6c9cb91e122e345e0440e18c6/analysis/gitauthors.py#L15 will have `TypeError: category type does not support sum operations` due to https://github.com/pandas-dev/pandas/issues/46072. This can be fixed by `authors_grouped.sum(numeric_only=True)`.

https://github.com/vifactor/repostat/blob/fc6e974e0010c2d6c9cb91e122e345e0440e18c6/report/htmlreportcreator.py#L79 will have `AttributeError: 'DataFrame' object has no attribute 'append'` due to https://github.com/pandas-dev/pandas/issues/35407. This can be fixed with concat or loc.

It was tested in Python 3.8 with both pandas 1.3.3 and pandas 2.0.1 and Python 3.11 with pandas 2.0.1.
I have also added Python 3.10 and 3.11 to the Ubuntu workflow and edited README.